### PR TITLE
Update dependencies (Fixes #7)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var d3 = {
   scale: require("d3-scale"),
   time: require("d3-time"),
-  extent: require("d3-arrays").extent
+  extent: require("d3-array").extent
 };
 
 // These are the comparison types available to use as
@@ -155,7 +155,7 @@ function generateNumericBinning(data, column, numBins){
   var rawAccessor = accessor(column);
   var count = numBins + 1;
 
-  var ticks = d3.scale.linear()
+  var ticks = d3.scale.scaleLinear()
     .domain(d3.extent(data, rawAccessor))
     .nice(count)
     .ticks(count);

--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
   },
   "homepage": "https://github.com/curran/data-reduction",
   "dependencies": {
-    "d3-arrays": "^0.4.0",
-    "d3-scale": "^0.1.5",
-    "d3-time": "0.0.7"
+    "d3-array": "^1.0.1",
+    "d3-scale": "^1.0.3",
+    "d3-time": "^1.0.2"
   },
   "devDependencies": {
     "chiasm-dataset": "^0.1.1",
-    "mocha": "^2.2.5"
+    "mocha": "^3.0.2"
   }
 }

--- a/test.js
+++ b/test.js
@@ -192,7 +192,7 @@ describe("data-reduction", function () {
           column: "foo"
         }],
         measures: [{
-          outColumn: "total", 
+          outColumn: "total",
           operator: "count"
         }]
       }
@@ -217,7 +217,7 @@ describe("data-reduction", function () {
           numBins: 3
         }],
         measures: [{
-          outColumn: "total", 
+          outColumn: "total",
           operator: "count"
         }]
       }
@@ -246,7 +246,7 @@ describe("data-reduction", function () {
           column: "bar"
         }],
         measures: [{
-          outColumn: "total", 
+          outColumn: "total",
           operator: "count"
         }]
       }
@@ -268,17 +268,17 @@ describe("data-reduction", function () {
       aggregate: {
         dimensions: [{
           column: "timestamp",
-          timeInterval: "day"
+          timeInterval: "timeDay"
         }],
         measures: [{
-          outColumn: "total", 
+          outColumn: "total",
           operator: "count"
         }]
       }
     });
 
     var timeMetadata = getColumnMetadata(result, "timestamp");
-    assert.equal(timeMetadata.interval, "day");
+    assert.equal(timeMetadata.interval, "timeDay");
 
     ChiasmDataset.validate(result).then(done, console.log);
   });


### PR DESCRIPTION
Because of the changes in d3-time interval formats this might be considered a major (i.e. breaking) change.  See line https://github.com/curran/data-reduction/pull/8/files#diff-1dd241c4cd3fd1dd89c570cee98b79ddL271.
